### PR TITLE
Now all recent stm32f<n>xx STM32 GNU ARM C/C++ Project templates can also be used as a destination eclipse project.

### DIFF
--- a/cubemximporter.py
+++ b/cubemximporter.py
@@ -19,10 +19,12 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+#
+# modified by Fabien to get the new gnu arm stm32 project templates to also work with the script
 
 from __future__ import print_function
 
-version = 0.2
+version = '0.2.1' # using semantic versioning 2.0 model, denote a patch change
 
 import os
 import argparse
@@ -32,11 +34,13 @@ import shutil
 import re
 from lxml import etree
 
+
 class CubeMXImporter(object):
     """docstring for CubeMXImporter"""
+
     def __init__(self):
         super(CubeMXImporter, self).__init__()
-        
+
         self.eclipseprojectpath = ""
         self.dryrun = 0
         self.logger = logging.getLogger(__name__)
@@ -45,36 +49,37 @@ class CubeMXImporter(object):
     def setCubeMXProjectPath(self, path):
         """Set the path of CubeMX generated project folder"""
 
-        if os.path.exists(os.path.join(path, ".mxproject")): 
-            if os.path.exists(os.path.join(path, "SW4STM32")):  #For CubeMX < 4.14
+        if os.path.exists(os.path.join(path, ".mxproject")):
+            if os.path.exists(os.path.join(path, "SW4STM32")):  # For CubeMX < 4.14
                 self.cubemxprojectpath = path
                 self.sw4stm32projectpath = os.path.join(path, "SW4STM32")
                 self.detectHALInfo()
             elif os.path.exists(os.path.join(path, ".cproject")):
-                #Recent releases of CubeMX (from 4.14 and higher) allow to generate the
-                #SW4STM32 project in the root folder. This means that project files are 
-                #stored in the root of the CubeMX project, but this is the 
-                #same behavior for TrueSTUDIO project. So we need to check if the project
-                #is generated for the SW4STM32 toolchain by playing with the content of .cproject file
+                # Recent releases of CubeMX (from 4.14 and higher) allow to generate the
+                # SW4STM32 project in the root folder. This means that project files are
+                # stored in the root of the CubeMX project, but this is the
+                # same behavior for TrueSTUDIO project. So we need to check if the project
+                # is generated for the SW4STM32 toolchain by playing with the content of .cproject file
 
-                if open(os.path.join(path, ".cproject")).read().find("ac6") < 0: #It is not an AC6 project
-                    raise InvalidSW4STM32Project("The generated CubeMX project is not for SW4STM32 tool-chain. Please, regenerate the project again.")
+                if open(os.path.join(path, ".cproject")).read().find("ac6") < 0:  # It is not an AC6 project
+                    raise InvalidSW4STM32Project(
+                        "The generated CubeMX project is not for SW4STM32 tool-chain. Please, regenerate the project again.")
                 else:
                     self.cubemxprojectpath = path
                     self.sw4stm32projectpath = path
                     self.detectHALInfo()
 
             else:
-                raise InvalidSW4STM32Project("The generated CubeMX project is not for SW4STM32 tool-chain. Please, regenerate the project again.")
+                raise InvalidSW4STM32Project(
+                    "The generated CubeMX project is not for SW4STM32 tool-chain. Please, regenerate the project again.")
         else:
             raise InvalidCubeMXFolder("The folder '%s' doesn't seem a CubeMX project" % path)
-            
-    def getCubeMXProjectPath(self):
-        """Retrieve the path of CubeMX generated project folder"""        
-        return self.cubemxprojectpath
-        
-    cubeMXProjectPath = property(getCubeMXProjectPath, setCubeMXProjectPath)
 
+    def getCubeMXProjectPath(self):
+        """Retrieve the path of CubeMX generated project folder"""
+        return self.cubemxprojectpath
+
+    cubeMXProjectPath = property(getCubeMXProjectPath, setCubeMXProjectPath)
 
     def setEclipseProjectPath(self, path):
         """Set the path of Eclipse generated project folder"""
@@ -83,25 +88,26 @@ class CubeMXImporter(object):
             self.eclipseprojectpath = path
         else:
             raise InvalidEclipseFolder("The folder '%s' doesn't seem an Eclipse project" % path)
-            
+
     def getEclipseProjectPath(self):
-        """Retrieve the path of Eclipse generated project folder"""        
+        """Retrieve the path of Eclipse generated project folder"""
         return self.eclipseprojectpath
-        
+
     eclipseProjectPath = property(getEclipseProjectPath, setEclipseProjectPath)
-        
+
     def __addOptionValuesToProject(self, values, section, quote=True):
         if self.dryrun: return
         """Add a list of option values into a given section in the Eclipse project file"""
-        options = self.projectRoot.xpath("//option[@superClass='%s']" % section) #Uses XPATH to retrieve the 'section'
-        optionsValues = [o.attrib["value"] for o in options[0]] #List all available values to avoid reinsert again the same value
+        options = self.projectRoot.xpath("//option[@superClass='%s']" % section)  # Uses XPATH to retrieve the 'section'
+        optionsValues = [o.attrib["value"] for o in
+                         options[0]]  # List all available values to avoid reinsert again the same value
         for opt in options:
             for v in values:
-                pattern = '"%s"' if quote else '%s' #The way how include paths and macros are stored differs. Include paths are quoted with ""
-                if pattern % v not in optionsValues: #Avoid to place the same include again
+                pattern = '"%s"' if quote else '%s'  # The way how include paths and macros are stored differs. Include paths are quoted with ""
+                if pattern % v not in optionsValues:  # Avoid to place the same include again
                     listOptionValue = copy.deepcopy(opt[0])
                     if quote:
-                        listOptionValue.attrib["value"] = "&quot;%s&quot;" % v #Quote the path
+                        listOptionValue.attrib["value"] = "&quot;%s&quot;" % v  # Quote the path
                     else:
                         listOptionValue.attrib["value"] = "%s" % v
                     opt.append(listOptionValue)
@@ -112,12 +118,13 @@ class CubeMXImporter(object):
 
     def addCIncludes(self, includes):
         """Add a list of include paths to the C section in project settings"""
-        self.__addOptionValuesToProject(includes, "ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.include.paths")
+        self.__addOptionValuesToProject(includes,
+                                        "ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.include.paths")
 
     def addCPPIncludes(self, includes):
         """Add a list of include paths to the CPP section in project settings"""
-        self.__addOptionValuesToProject(includes, "ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.include.paths")
-
+        self.__addOptionValuesToProject(includes,
+                                        "ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.include.paths")
 
     def addAssemblerMacros(self, macros):
         """Add a list of macros to the CPP section in project settings"""
@@ -126,14 +133,14 @@ class CubeMXImporter(object):
     def addCMacros(self, macros):
         """Add a list of macros to the CPP section in project settings"""
         self.__addOptionValuesToProject(macros, "ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.defs", False)
-                        
+
     def addCPPMacros(self, macros):
         """Add a list of macros to the CPP section in project settings"""
         self.__addOptionValuesToProject(macros, "ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.defs", False)
 
     def addSourceEntries(self, entries):
         """Add a list of directory to the source entries list in the eclipse project"""
-        sources = self.projectRoot.xpath("//sourceEntries") #Uses XPATH to retrieve the 'section'
+        sources = self.projectRoot.xpath("//sourceEntries")  # Uses XPATH to retrieve the 'section'
         for source in sources:
             for e in entries:
                 logging.debug("Adding '%s' folder to source entries" % e)
@@ -162,22 +169,34 @@ class CubeMXImporter(object):
                 if not self.dryrun:
                     shutil.copytree(fileToCopy, os.path.join(dst, f))
 
+    def purge(self, rootdir, pattern):
+        for f in os.listdir(rootdir):
+            if re.search(pattern, f):
+                path = os.path.join(rootdir, f)
+                logging.debug("Deleting %s" % path)
+                if os.path.isfile(path):
+                    os.remove(path)
+                elif os.path.isdir(path):
+                    shutil.rmtree(path)
+
     def deleteOriginalEclipseProjectFiles(self):
         """Deletes useless files generated by the GNU ARM Eclipse plugin"""
-        
-        dirs = ["src", "include", "system/src/cmsis", "system/src/stm32%sxx" % self.HAL_TYPE.lower(), "system/include/stm32%sxx" % self.HAL_TYPE.lower()]
 
-        [self.deleteTreeContent(os.path.join(self.eclipseprojectpath, d)) for d in dirs]
+        # search for any original or alternate -stdperiph pattern:
+        dirs = ["src", "include", "system/src/cmsis"]
+        dirs2 = ["system/include/", "system/src/"]
+        stm32_dir_pat = "stm32%s(xx|-stdperiph)" % self.HAL_TYPE.lower()
+        stm32_h_pat  = '(system_)*stm32%s.*.h$' % self.HAL_TYPE.lower()
 
-        files = ["system/include/cmsis/stm32%sxx.h" % self.HAL_TYPE.lower(), "system/include/cmsis/system_stm32%sxx.h" % self.HAL_TYPE.lower()]
-        
-        try:
-            if not self.dryrun:
-                [os.unlink(os.path.join(self.eclipseprojectpath, f)) for f in files]
-        except OSError:
-            pass
 
-        self.logger.info("Deleted uneeded files generated by GNU Eclipse plugin")
+        if not self.dryrun:
+            [self.deleteTreeContent(os.path.join(self.eclipseprojectpath, d)) for d in dirs]
+            [self.purge(os.path.join(self.eclipseprojectpath, d), stm32_dir_pat) for d in dirs2]
+            self.purge(os.path.join(self.eclipseprojectpath, "system/include/cmsis/"), stm32_h_pat)
+            rdirs = [os.path.join(self.eclipseprojectpath, d, "stm32%sxx" % self.HAL_TYPE.lower()) for d in dirs2]
+            [os.makedirs(d ) for d in rdirs]
+            self.fixDeviceInclude()
+        self.logger.info("Deleted unneeded files generated by GNU Eclipse plugin")
 
     def deleteTreeContent(self, tree):
         """Delete all files contained in a given folder"""
@@ -200,7 +219,8 @@ class CubeMXImporter(object):
                 root = etree.fromstring(open(os.path.join(rootdir, ".cproject")).read().encode('UTF-8'))
 
         if root is None:
-            raise InvalidSW4STM32Project("The generated CubeMX project is not for SW4STM32 tool-chain. Please, regenerate the project again.")
+            raise InvalidSW4STM32Project(
+                "The generated CubeMX project is not for SW4STM32 tool-chain. Please, regenerate the project again.")
 
         options = root.xpath("//option[@superClass='gnu.c.compiler.option.preprocessor.def.symbols']")[0]
 
@@ -219,7 +239,8 @@ class CubeMXImporter(object):
                 root = etree.fromstring(open(os.path.join(rootdir, ".cproject")).read().encode('UTF-8'))
 
         if root is None:
-            raise InvalidSW4STM32Project("The generated CubeMX project is not for SW4STM32 tool-chain. Please, regenerate the project again.")
+            raise InvalidSW4STM32Project(
+                "The generated CubeMX project is not for SW4STM32 tool-chain. Please, regenerate the project again.")
 
         options = root.xpath("//option[@superClass='gnu.c.compiler.option.include.paths']")[0]
 
@@ -241,7 +262,8 @@ class CubeMXImporter(object):
 
     def importCMSIS(self):
         """Import CMSIS package and CMSIS-DEVICE adapter by ST inside the Eclipse project"""
-        srcIncludeDir = os.path.join(self.cubemxprojectpath, "Drivers/CMSIS/Device/ST/STM32%sxx/Include" % self.HAL_TYPE)
+        srcIncludeDir = os.path.join(self.cubemxprojectpath,
+                                     "Drivers/CMSIS/Device/ST/STM32%sxx/Include" % self.HAL_TYPE)
         dstIncludeDir = os.path.join(self.eclipseprojectpath, "system/include/cmsis/device")
         srcCMSISIncludeDir = os.path.join(self.cubemxprojectpath, "Drivers/CMSIS/Include")
         dstCMSISIncludeDir = os.path.join(self.eclipseprojectpath, "system/include/cmsis")
@@ -253,7 +275,11 @@ class CubeMXImporter(object):
         except OSError:
             pass
 
-        #Add includes to the project settings
+        # Add hal includes for variants with otehr folder names
+        self.addCIncludes(("../system/include/stm32%sxx" % self.HAL_TYPE.lower(),))
+        self.addCPPIncludes(("../system/include/stm32%sxx" % self.HAL_TYPE.lower(),))
+
+        # Add includes to the project settings
         self.addCIncludes(("../system/include/cmsis/device",))
         self.addCPPIncludes(("../system/include/cmsis/device",))
         self.addAssemblerIncludes(("../system/include/cmsis/device",))
@@ -264,17 +290,23 @@ class CubeMXImporter(object):
         for loc in locations:
             self.copyTreeContent(loc[0], loc[1])
 
-        systemFile = os.path.join(self.cubemxprojectpath, "Drivers/CMSIS/Device/ST/STM32%sxx/Source/Templates/system_stm32%sxx.c" % (self.HAL_TYPE, self.HAL_TYPE.lower()))
-        startupFile = os.path.join(self.cubemxprojectpath, "Drivers/CMSIS/Device/ST/STM32%sxx/Source/Templates/gcc/startup_%s.s" % (self.HAL_TYPE, self.HAL_MCU_TYPE.lower()))
-            
+        systemFile = os.path.join(self.cubemxprojectpath,
+                                  "Drivers/CMSIS/Device/ST/STM32%sxx/Source/Templates/system_stm32%sxx.c" % (
+                                      self.HAL_TYPE, self.HAL_TYPE.lower()))
+        startupFile = os.path.join(self.cubemxprojectpath,
+                                   "Drivers/CMSIS/Device/ST/STM32%sxx/Source/Templates/gcc/startup_%s.s" % (
+                                       self.HAL_TYPE, self.HAL_MCU_TYPE.lower()))
+
         locations = ((systemFile, dstSourceDir), (startupFile, dstSourceDir))
 
         if not self.dryrun:
             for loc in locations:
                 shutil.copy(loc[0], loc[1])
 
-            os.rename(os.path.join(self.eclipseprojectpath, "system/src/cmsis/startup_%s.s" % self.HAL_MCU_TYPE.lower()), os.path.join(self.eclipseprojectpath, "system/src/cmsis/startup_%s.S" % self.HAL_MCU_TYPE.lower()))
-    
+            os.rename(
+                os.path.join(self.eclipseprojectpath, "system/src/cmsis/startup_%s.s" % self.HAL_MCU_TYPE.lower()),
+                os.path.join(self.eclipseprojectpath, "system/src/cmsis/startup_%s.S" % self.HAL_MCU_TYPE.lower()))
+
         self.logger.info("Successfully imported CMSIS files")
 
     def importHAL(self):
@@ -295,11 +327,14 @@ class CubeMXImporter(object):
 
         if not self.dryrun:
             try:
-                #Try to delete templete files, if generated
-                os.unlink(os.path.join(self.eclipseprojectpath, "system/src/stm32%sxx/stm32%sxx_hal_msp_template.c" % (self.HAL_TYPE.lower(), self.HAL_TYPE.lower())))
-                os.unlink(os.path.join(self.eclipseprojectpath, "system/src/stm32%sxx/stm32%sxx_hal_timebase_tim_template.c" % (self.HAL_TYPE.lower(), self.HAL_TYPE.lower())))
+                # Try to delete templete files, if generated
+                os.unlink(os.path.join(self.eclipseprojectpath, "system/src/stm32%sxx/stm32%sxx_hal_msp_template.c" % (
+                    self.HAL_TYPE.lower(), self.HAL_TYPE.lower())))
+                os.unlink(os.path.join(self.eclipseprojectpath,
+                                       "system/src/stm32%sxx/stm32%sxx_hal_timebase_tim_template.c" % (
+                                           self.HAL_TYPE.lower(), self.HAL_TYPE.lower())))
             except OSError:
-                pass                
+                pass
 
         self.logger.info("Successfully imported the STCubeHAL")
 
@@ -338,21 +373,22 @@ class CubeMXImporter(object):
                 shutil.rmtree(dstDir)
                 return self.importMiddlewares()
 
-        #Adding Middleware library includes
+        # Adding Middleware library includes
         includes = [inc.replace("../../", "") for inc in self.getAC6Includes() if "Middlewares" in inc]
 
         self.addCIncludes(includes)
         self.addCPPIncludes(includes)
         self.addAssemblerIncludes(includes)
         self.addSourceEntries(("Middlewares",))
- 
+
         self.logger.info("Successfully imported Middlewares libraries")
 
         if foundLwIP:
             try:
-                ethernetif_template = os.path.join(self.eclipseprojectpath, "Middlewares/Third_Party/LwIP/src/netif/ethernetif_template.c")
+                ethernetif_template = os.path.join(self.eclipseprojectpath,
+                                                   "Middlewares/Third_Party/LwIP/src/netif/ethernetif_template.c")
                 os.unlink(ethernetif_template)
-            except OSError:  #CubeMX 4.14 no longer generates this file
+            except OSError:  # CubeMX 4.14 no longer generates this file
                 pass
 
         if foundFreeRTOS:
@@ -377,28 +413,28 @@ Moreover, exclude from build those MemManage files (heap_1.c, etc) not needed fo
 This library was imported in the Eclipse project correctly, but you still need to
 exclude from build those uneeded codepage files (cc932.c, etc) not needed for your project.""")
 
-        
     def parseEclipseProjectFile(self):
         """Parse the Eclipse XML project file"""
         projectFile = os.path.join(self.eclipseprojectpath, ".cproject")
         self.projectRoot = etree.fromstring(open(projectFile).read().encode('UTF-8'))
-        
+
     def printEclipseProjectFile(self):
         """Do a pretty print of Eclipse project DOM"""
         xmlout = etree.tostring(self.projectRoot, pretty_print=True)
-        #lxml correctly escapes the "&" to "&amp;", as specified by the XML standard.
-        #However, Eclipse expects that the " charachter is espressed as &quot; So,
-        #here we replace the "&amp;" with "&" in the final XML file
+        # lxml correctly escapes the "&" to "&amp;", as specified by the XML standard.
+        # However, Eclipse expects that the " charachter is espressed as &quot; So,
+        # here we replace the "&amp;" with "&" in the final XML file
         xmlout = xmlout.replace("&amp;", "&")
         print(xmlout)
 
     def saveEclipseProjectFile(self):
         """Save the XML DOM of Eclipse project inside the .cproject file"""
 
-        xmlout = '<?xml version="1.0" encoding="UTF-8" standalone="no"?><?fileVersion 4.0.0?>' + etree.tostring(self.projectRoot).decode('UTF-8')
-        #lxml correctly escapes the "&" to "&amp;", as specified by the XML standard.
-        #However, Eclipse expects that the " charachter is espressed as &quot; So,
-        #here we replace the "&amp;" with "&" in the final XML file
+        xmlout = '<?xml version="1.0" encoding="UTF-8" standalone="no"?><?fileVersion 4.0.0?>' + etree.tostring(
+            self.projectRoot).decode('UTF-8')
+        # lxml correctly escapes the "&" to "&amp;", as specified by the XML standard.
+        # However, Eclipse expects that the " charachter is espressed as &quot; So,
+        # here we replace the "&amp;" with "&" in the final XML file
         xmlout = xmlout.replace("&amp;", "&")
         projectFile = os.path.join(self.eclipseprojectpath, ".cproject")
         if not self.dryrun:
@@ -407,32 +443,51 @@ exclude from build those uneeded codepage files (cc932.c, etc) not needed for yo
     def setDryRun(self, dryrun):
         """Enable dryrun mode: it does't execute operations on projects"""
         self.dryrun = dryrun
-        if(dryrun > 0):
+        if dryrun > 0:
             self.logger.debug("Running in DryRun mode: the Eclipse project will not be modified")
+
+    def fixDeviceInclude(self):
+        """Set the correct include file inside the cmsis device include if exists, this will work even if old naming was present"""
+        filename_in = os.path.join(self.eclipseprojectpath, "system/include/cmsis/cmsis_device.h")
+        filename_out = filename_in + '.tmp'
+        if os.path.isfile(filename_in):
+            with open(filename_out, "wt") as fout:
+                with open(filename_in, "rt") as fin:
+                    for line in fin:
+                        if re.search('^#include .*stm32.*\.h.*$', line):
+                            fout.write('#include "stm32%sxx.h"\n' % self.HAL_TYPE.lower())
+                        else:
+                            fout.write(line)
+            os.remove(filename_in)
+            os.rename(filename_out, filename_in)
 
 class InvalidCubeMXFolder(Exception):
     pass
-            
+
+
 class InvalidEclipseFolder(Exception):
     pass
 
+
 class InvalidSW4STM32Project(Exception):
     pass
-        
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Import a CubeMX generated project inside an existing Eclipse project generated with the GNU ARM plugin')
-    
-    parser.add_argument('eclipse_path', metavar='eclipse_project_folder', type=str, 
-                       help='an integer for the accumulator')
 
-    parser.add_argument('cubemx_path', metavar='cubemx_project_folder', type=str, 
-                       help='an integer for the accumulator')
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description='Import a CubeMX generated project inside an existing Eclipse project generated with the GNU ARM plugin')
+
+    parser.add_argument('eclipse_path', metavar='eclipse_dest_prj_path', type=str,
+                        help='eclipse destination project path')
+
+    parser.add_argument('cubemx_path', metavar='cubemx_src_prj_path', type=str,
+                        help='cube_mx source project path')
 
     parser.add_argument('-v', '--verbose', type=int, action='store',
-                       help='Verbose level')
+                        help='Verbose level')
 
-    parser.add_argument('--dryrun', action='store_true', 
-                       help="Doesn't perform operations - for debug purpose")
+    parser.add_argument('--dryrun', action='store_true',
+                        help="Doesn't perform operations - for debug purpose")
 
     args = parser.parse_args()
 
@@ -441,9 +496,9 @@ if __name__ == "__main__":
     if args.verbose == 2:
         logging.basicConfig(level=logging.INFO)
     else:
-        logging.basicConfig(level=logging.ERROR )
+        logging.basicConfig(level=logging.ERROR)
 
-    cubeImporter =  CubeMXImporter()
+    cubeImporter = CubeMXImporter()
     cubeImporter.setDryRun(args.dryrun)
     cubeImporter.eclipseProjectPath = args.eclipse_path
     cubeImporter.cubeMXProjectPath = args.cubemx_path


### PR DESCRIPTION
…able for direct cubemx injection as opposed to be limited to general cortex project template. Worked well with my cheap STM32F103C8T6 board.

Added more folder naming adaptation as well as on the fly cmsis_device correct generation whatever the project template approach is.
new methods  fixDeviceInclude() and a handy purge() made possible new eclipse targets to work.

Now fully builds with no manual patch needed. and also debug works (tested with openocd on stm32f103c8t6 $3 board).

Some minor  cleanup was done with PyCharm.
