### PR TITLE
Added a sync-back feature of copying modified Application files back to CubeMX

### DIFF
--- a/cubemximporter.py
+++ b/cubemximporter.py
@@ -258,6 +258,20 @@ class CubeMXImporter(object):
 
         self.logger.info("Successfully imported application files")
 
+    def syncBackApplication(self):
+        """Import generated application code inside the Eclipse project"""
+        dstIncludeDir = os.path.join(self.cubemxprojectpath, "Inc")
+        dstSourceDir = os.path.join(self.cubemxprojectpath, "Src")
+        srcIncludeDir = os.path.join(self.eclipseprojectpath, "include")
+        srcSourceDir = os.path.join(self.eclipseprojectpath, "src")
+
+        locations = ((srcIncludeDir, dstIncludeDir), (srcSourceDir, dstSourceDir))
+
+        for loc in locations:
+            self.copyTreeContent(loc[0], loc[1])
+
+        self.logger.info("Successfully synced back application files")
+
     def importCMSIS(self):
         """Import CMSIS package and CMSIS-DEVICE adapter by ST inside the Eclipse project"""
         cubeMXVersion = 417
@@ -522,6 +536,10 @@ if __name__ == "__main__":
     parser.add_argument('--dryrun', action='store_true',
                         help="Doesn't perform operations - for debug purpose")
 
+    parser.add_argument('--syncback', action='store_true',
+                        help="Synchronize the application files in Eclipse's Src directory back to CubeMX project")
+
+
     args = parser.parse_args()
 
     if args.verbose == 3:
@@ -536,12 +554,15 @@ if __name__ == "__main__":
     cubeImporter.eclipseProjectPath = args.eclipse_path
     cubeImporter.cubeMXProjectPath = args.cubemx_path
     cubeImporter.parseEclipseProjectFile()
-    cubeImporter.deleteOriginalEclipseProjectFiles()
-    cubeImporter.importApplication()
-    cubeImporter.importHAL()
-    cubeImporter.importCMSIS()
-    cubeImporter.importMiddlewares()
-    cubeImporter.saveEclipseProjectFile()
-    cubeImporter.patchMEM_LDFile()
-    # cubeImporter.addCIncludes(["../middlewares/freertos"])
-    # cubeImporter.printEclipseProjectFile()
+    if not args.syncback:
+        cubeImporter.deleteOriginalEclipseProjectFiles()
+        cubeImporter.importApplication()
+        cubeImporter.importHAL()
+        cubeImporter.importCMSIS()
+        cubeImporter.importMiddlewares()
+        cubeImporter.saveEclipseProjectFile()
+        cubeImporter.patchMEM_LDFile()
+        # cubeImporter.addCIncludes(["../middlewares/freertos"])
+        # cubeImporter.printEclipseProjectFile()
+    else:
+        cubeImporter.syncBackApplication()


### PR DESCRIPTION
This feature simply copies Application files from Eclipse folder back to CubeMX. It is useful in cases when you want to make some changes in CubeMX project and not loose your user code when you generate CubeMX again. Using this feature you may add your own code in sections marked by "/* USER CODE ..." in Eclipse and then still have them after regenerating the code in CubeMX. For this to work the flag "Keep User Code when re-generating" must be set in CubeMX's Project->Code Generator settings.
The workflow to update CubeMX configuration and retain user code is following:
1. Run cubemximporter with the --syncback argument
2. Generate new code in CubeMX
2. Run cubemximporter normally